### PR TITLE
fixed `go-koans-run` for >= Emacs 26.1

### DIFF
--- a/go-koans.el
+++ b/go-koans.el
@@ -12,7 +12,9 @@
   (when (string-match "\\(about_[A-Za-z0-9_]*.go\\):\\([0-9]+\\)" output)
 
     (let
-        ((line (string-to-int (match-string 2 output)))
+        ((line (if (fboundp 'string-to-number)
+                   (string-to-number (match-string 2 output))
+                   (string-to-int (match-string 2 output))))
          (file (expand-file-name (match-string 1 output))))
 
       (find-file (expand-file-name file))


### PR DESCRIPTION
If Emacs version is greater equal than 26.1, then below error occurs on `go-koan-run`.

```
let: Symbol’s function definition is void: string-to-int
```

SEE: https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.26#L1279-L1284